### PR TITLE
explicity expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,5 @@ VOLUME /var/lib/pypicloud
 
 # Add the command for easily creating config files
 ADD make-config.sh /sbin/make-config
+
+EXPOSE 8080


### PR DESCRIPTION
This needs to be done for Salt, otherwise it'll silently ignore your $HOST:8080 binding.