### PR TITLE
Make uwsgi shell script executable for my_init

### DIFF
--- a/py2-baseimage/Dockerfile
+++ b/py2-baseimage/Dockerfile
@@ -17,8 +17,9 @@ RUN apt-get update -qq \
   # Make sure this directory exists for the baseimage init
   && mkdir -p /etc/my_init.d
 
-# Add the startup service
+# Add the startup service and make it executable
 ADD pypicloud-uwsgi.sh /etc/my_init.d/pypicloud-uwsgi.sh
+RUN chmod +x /etc/my_init.d/pypicloud-uwsgi.sh
 
 # Add the pypicloud config file
 RUN mkdir -p /etc/pypicloud

--- a/py3-baseimage/Dockerfile
+++ b/py3-baseimage/Dockerfile
@@ -17,8 +17,9 @@ RUN apt-get update -qq \
   # Make sure this directory exists for the baseimage init
   && mkdir -p /etc/my_init.d
 
-# Add the startup service
+# Add the startup service and make it executable
 ADD pypicloud-uwsgi.sh /etc/my_init.d/pypicloud-uwsgi.sh
+RUN chmod +x /etc/my_init.d/pypicloud-uwsgi.sh
 
 # Add the pypicloud config file
 RUN mkdir -p /etc/pypicloud


### PR DESCRIPTION
I was trying to run the `py3-baseimage` Dockerfile and noticed that the `pypicloud-uwsgi.sh` script was not running. After digging into the `my_init` script, I noticed that it checks if files inside of `/etc/my_init.d` are executable. If they are, it runs them. I added a `chmod +x` to the Dockerfile and then the script ran as expected.

- [x] Make `pypicloud-uwsgi.sh` executable so `my_init` script will run it