### PR TITLE
Fix build by switching to newer baseimage

### DIFF
--- a/py3-baseimage/Dockerfile
+++ b/py3-baseimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.10.0
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Steven Arcangeli <stevearc@stevearc.com>
 
 ENV PYPICLOUD_VERSION 1.1.7


### PR DESCRIPTION
The build currently fails on cryptography package, probably due to old pip/setuptools. Since the baseimage version is quite antiquated, I think the simplest solution here is to update it. This builds successfully.