### PR TITLE
Add multi-arch support to build.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - run: bash build.sh
+      - run: bash build.sh --publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  release:
+    types: [released, prereleased]
+  workflow_dispatch:  # allow manually running from the Actions tab
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: bash build.sh


### PR DESCRIPTION
Will additionally push armv8 (arm64) and armv7 (32bit) docker images to dockerhub when a github release is (pre)released, or manually from the Actions tab after pushing a tag (but not releasing it as github release).

The script can still be used locally with a recent docker version that comes with buildx, also without QEMU emulator installed, to build and push the AMD image only (the default if `BUILDX_PLATFORMS` env var is not set)

pushing multi-arch manifest separately from the build command like it was is iffy ([`regctl`](https://github.com/regclient/regclient) needed), so just running build command again but with `--push`, which should be minimal overhead.